### PR TITLE
Fix Gateway handling of GET requests with empty bodies

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -180,10 +180,19 @@ func (gw *APIGateway) forwardToBackend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Handle empty request bodies for GET requests
+	var requestBody json.RawMessage
+	if len(body) == 0 {
+		// For empty bodies (like GET requests), use empty JSON object
+		requestBody = json.RawMessage("{}")
+	} else {
+		requestBody = json.RawMessage(body)
+	}
+
 	requestData := models.ServiceRequest{
 		ServiceID: gw.serviceID,
 		Timestamp: time.Now(),
-		Data:      body,
+		Data:      requestBody,
 		Headers:   make(map[string]string),
 	}
 


### PR DESCRIPTION
## Summary
- Fixes Gateway's inability to process GET requests with empty bodies
- Resolves JSON marshaling errors that caused 500 Internal Server Error responses
- Enables proper RESTful API support through the Gateway

## Problem Description
The API Gateway's `forwardToBackend()` function failed when processing GET requests without request bodies (such as `GET /status`). The issue occurred because:

1. Empty request bodies (0-byte arrays) were being assigned to `json.RawMessage` fields
2. JSON marshaling of empty byte arrays as `json.RawMessage` fails with "unexpected end of JSON input"
3. This caused the `make demo` command to fail on status endpoint checks

## Root Cause
In `cmd/gateway/main.go`, line 186 assigned raw body bytes directly to the `Data` field:
```go
requestData := models.ServiceRequest{
    // ...
    Data: body,  // This fails when body is empty for GET requests
    // ...
}
```

When `body` is empty (common for GET requests), JSON marshaling fails because `json.RawMessage` expects valid JSON.

## Solution
Added proper handling for empty request bodies:

```go
// Handle empty request bodies for GET requests
var requestBody json.RawMessage
if len(body) == 0 {
    // For empty bodies (like GET requests), use empty JSON object
    requestBody = json.RawMessage("{}")
} else {
    requestBody = json.RawMessage(body)
}

requestData := models.ServiceRequest{
    // ...
    Data: requestBody,
    // ...
}
```

## Impact
✅ **Before Fix:**
- `curl -X GET http://localhost:8081/status` → 500 Internal Server Error
- `make demo` command failed on status check
- GET requests not supported through Gateway

✅ **After Fix:**
- GET requests work perfectly with proper JSON responses
- `make demo` passes completely 
- Full Post-Quantum Cryptography authentication maintained
- All existing functionality preserved

## Test Results
**Comprehensive testing completed:**
- ✅ Health checks: All services responding
- ✅ Echo endpoint: Working with PQC signatures  
- ✅ Data processing endpoint: Working with PQC signatures
- ✅ **Status endpoint: NOW WORKING with GET requests**
- ✅ Complete demo flow: All endpoints functional

## Files Changed
- `cmd/gateway/main.go`: Added empty body handling logic

## Verification
Run the full demo to verify the fix:
```bash
make demo
```

All endpoints should now work properly with Post-Quantum Cryptography authentication.

**Fixes #4**

🤖 Generated with [Claude Code](https://claude.ai/code)